### PR TITLE
"duplicate of" mantis bug relationships can be empty

### DIFF
--- a/src/pyfaf/bugtrackers/mantisbt.py
+++ b/src/pyfaf/bugtrackers/mantisbt.py
@@ -153,7 +153,7 @@ class Mantis(BugTracker):
             return None
 
         if bug_dict["resolution"] == "DUPLICATE":
-            for relationship in bug.relationships:
+            for relationship in bug.relationships or []:
                 if relationship.type.name == "duplicate of":
                     bug_dict["dupe_id"] = relationship.target_id
                     break


### PR DESCRIPTION
Wards against bugs that make mantibt code break, such as https://bugs.centos.org/view.php?id=11115